### PR TITLE
Branch update pre board testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.pio
+.vscode/.browse.c_cpp.db*
+.vscode/c_cpp_properties.json
+.vscode/launch.json
+.vscode/ipch

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": false
+}

--- a/include/README
+++ b/include/README
@@ -1,0 +1,39 @@
+
+This directory is intended for project header files.
+
+A header file is a file containing C declarations and macro definitions
+to be shared between several project source files. You request the use of a
+header file in your project source file (C, C++, etc) located in `src` folder
+by including it, with the C preprocessing directive `#include'.
+
+```src/main.c
+
+#include "header.h"
+
+int main (void)
+{
+ ...
+}
+```
+
+Including a header file produces the same results as copying the header file
+into each source file that needs it. Such copying would be time-consuming
+and error-prone. With a header file, the related declarations appear
+in only one place. If they need to be changed, they can be changed in one
+place, and programs that include the header file will automatically use the
+new version when next recompiled. The header file eliminates the labor of
+finding and changing all the copies as well as the risk that a failure to
+find one copy will result in inconsistencies within a program.
+
+In C, the usual convention is to give header files names that end with `.h'.
+It is most portable to use only letters, digits, dashes, and underscores in
+header file names, and at most one dot.
+
+Read more about using header files in official GCC documentation:
+
+* Include Syntax
+* Include Operation
+* Once-Only Headers
+* Computed Includes
+
+https://gcc.gnu.org/onlinedocs/cpp/Header-Files.html

--- a/lib/README
+++ b/lib/README
@@ -1,0 +1,46 @@
+
+This directory is intended for project specific (private) libraries.
+PlatformIO will compile them to static libraries and link into executable file.
+
+The source code of each library should be placed in a an own separate directory
+("lib/your_library_name/[here are source files]").
+
+For example, see a structure of the following two libraries `Foo` and `Bar`:
+
+|--lib
+|  |
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |  |- library.json (optional, custom build options, etc) https://docs.platformio.org/page/librarymanager/config.html
+|  |
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |
+|  |- README --> THIS FILE
+|
+|- platformio.ini
+|--src
+   |- main.c
+
+and a contents of `src/main.c`:
+```
+#include <Foo.h>
+#include <Bar.h>
+
+int main (void)
+{
+  ...
+}
+
+```
+
+PlatformIO Library Dependency Finder will find automatically dependent
+libraries scanning project source files.
+
+More information about PlatformIO Library Dependency Finder
+- https://docs.platformio.org/page/librarymanager/ldf.html

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,16 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:uno]
+platform = atmelavr
+board = uno
+framework = arduino
+lib_deps = sparkfun/SparkFun Simultaneous RFID Tag Reader Library@^1.1.1
+monitor_speed = 115200

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,8 +18,12 @@
 #include <SoftwareSerial.h>           //If you run into compilation errors regarding this include, see README
 #include "SparkFun_UHF_RFID_Reader.h" //Library for controlling the M6E Nano module
 
+// CONSTANTS
+#define COUNT_MAX 500     // Maximum amount of tags to be scanned before stopping
+
 // GLOBAL VARIABLES
-bool formatCheck;     //Determines if data is printed to serial monitor as csv or with labels
+bool formatCheck;         // Determines if data is printed to serial monitor as csv or with labels
+int scanCount = 1;     // Tracks amount of tags scanned
 
 SoftwareSerial softSerial(2, 3); //RX, TX
 RFID nano; //Create instance
@@ -39,7 +43,8 @@ void printWithLabels()
     }
     else if (responseType == RESPONSE_IS_TAGFOUND)
     {
-      //If we have a full record we can pull out the fun bits
+      scanCount++;
+
       int rssi = nano.getTagRSSI(); //Get the RSSI for this tag read
 
       long freq = nano.getTagFreq(); //Get the frequency this tag was detected at
@@ -49,6 +54,10 @@ void printWithLabels()
       byte tagEPCBytes = nano.getTagEPCBytes(); //Get the number of bytes of EPC from response
 
       long phase = nano.getTagPhase();  //Get received tag phase from 0 to 180 degrees
+
+      Serial.print(F(" count["));
+      Serial.print(scanCount);
+      Serial.print(F("]"));
 
       Serial.print(F(" rssi["));
       Serial.print(rssi);
@@ -101,13 +110,15 @@ void printAsCSV()
 
     if (responseType == RESPONSE_IS_TAGFOUND)
     {
-      //If we have a full record we can pull out the fun bits
+      scanCount++;
       int rssi = nano.getTagRSSI(); //Get the RSSI for this tag read
       long freq = nano.getTagFreq(); //Get the frequency this tag was detected at
       long timeStamp = nano.getTagTimestamp(); //Get the time this was read, (ms) since last keep-alive message
       byte tagEPCBytes = nano.getTagEPCBytes(); //Get the number of bytes of EPC from response
       long phase = nano.getTagPhase();  //Get received tag phase from 0 to 180 degrees
 
+      Serial.print(count);
+      
       Serial.print(rssi);
       Serial.print(",");
       Serial.print(freq);
@@ -215,7 +226,7 @@ void setup()
   Serial.read(); //Throw away the user's character
 
   if(formatCheck) {
-    Serial.print("rssi, freq, timestamp, epc, phase\n");  //Print CSV header
+    Serial.print("count, rssi, freq, timestamp, epc, phase\n");  //Print CSV header
   }
 
   nano.startReading(); //Begin scanning for tags

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,229 @@
+/*
+  Reading multiple RFID tags, simultaneously!
+  By: Nathan Seidle @ SparkFun Electronics
+  Date: October 3rd, 2016
+  https://github.com/sparkfun/Simultaneous_RFID_Tag_Reader
+
+  Constantly reads and outputs any tags heard
+
+  If using the Simultaneous RFID Tag Reader (SRTR) shield, make sure the serial slide
+  switch is in the 'SW-UART' position
+
+  This code uses a modified version of the SparkFun_UHR_RFID_Reader library.
+  Versions downloaded online from SparkFun or the GitHub link above will not work.
+*/
+
+
+// LIBRARIES
+#include <SoftwareSerial.h>           //If you run into compilation errors regarding this include, see README
+#include "SparkFun_UHF_RFID_Reader.h" //Library for controlling the M6E Nano module
+
+// GLOBAL VARIABLES
+bool formatCheck;     //Determines if data is printed to serial monitor as csv or with labels
+
+SoftwareSerial softSerial(2, 3); //RX, TX
+RFID nano; //Create instance
+
+//Prints information from scanned tags to serial monitor with relevant labels
+//This will print errors and idle notes as well, this should be used if printing to serial
+//monitor in csv format is not necessary.
+void printWithLabels()
+{
+  if (nano.check() == true) //Check to see if any new data has come in from module
+  {
+    byte responseType = nano.parseResponse(); //Break response into tag ID, RSSI, frequency, and timestamp
+
+    if (responseType == RESPONSE_IS_KEEPALIVE)
+    {
+      Serial.println(F("Scanning"));
+    }
+    else if (responseType == RESPONSE_IS_TAGFOUND)
+    {
+      //If we have a full record we can pull out the fun bits
+      int rssi = nano.getTagRSSI(); //Get the RSSI for this tag read
+
+      long freq = nano.getTagFreq(); //Get the frequency this tag was detected at
+
+      long timeStamp = nano.getTagTimestamp(); //Get the time this was read, (ms) since last keep-alive message
+
+      byte tagEPCBytes = nano.getTagEPCBytes(); //Get the number of bytes of EPC from response
+
+      long phase = nano.getTagPhase();  //Get received tag phase from 0 to 180 degrees
+
+      Serial.print(F(" rssi["));
+      Serial.print(rssi);
+      Serial.print(F("]"));
+
+      Serial.print(F(" freq["));
+      Serial.print(freq);
+      Serial.print(F("]"));
+
+      Serial.print(F(" time["));
+      Serial.print(timeStamp);
+      Serial.print(F("]"));
+
+      //Print EPC bytes, this is a subsection of bytes from the response/msg array
+      Serial.print(F(" epc["));
+      for (byte x = 0 ; x < tagEPCBytes ; x++)
+      {
+        if (nano.msg[31 + x] < 0x10) Serial.print(F("0")); //Pretty print
+        Serial.print(nano.msg[31 + x], HEX);
+        Serial.print(F(" "));
+      }
+      Serial.print(F("]"));
+
+      Serial.print(F(" phase["));
+      Serial.print(phase);
+      Serial.print(F("]"));
+
+      Serial.println();
+    }
+    
+    else if (responseType == ERROR_CORRUPT_RESPONSE)
+    {
+      Serial.println("Bad CRC");
+    }
+    else
+    {
+      //Unknown response
+      Serial.print("Unknown error");
+    }
+  }
+}
+
+//Prints information from scanned tags to serial monitor in CSV format with header. 
+//This will not print errors and will remain idle if no tags are being scanned
+void printAsCSV()
+{
+  if (nano.check() == true) //Check to see if any new data has come in from module
+  {
+    byte responseType = nano.parseResponse(); //Break response into tag ID, RSSI, frequency, and timestamp
+
+    if (responseType == RESPONSE_IS_TAGFOUND)
+    {
+      //If we have a full record we can pull out the fun bits
+      int rssi = nano.getTagRSSI(); //Get the RSSI for this tag read
+      long freq = nano.getTagFreq(); //Get the frequency this tag was detected at
+      long timeStamp = nano.getTagTimestamp(); //Get the time this was read, (ms) since last keep-alive message
+      byte tagEPCBytes = nano.getTagEPCBytes(); //Get the number of bytes of EPC from response
+      long phase = nano.getTagPhase();  //Get received tag phase from 0 to 180 degrees
+
+      Serial.print(rssi);
+      Serial.print(",");
+      Serial.print(freq);
+      Serial.print(",");
+      Serial.print(timeStamp);
+      Serial.print(",");
+      for (byte x = 0 ; x < tagEPCBytes ; x++)
+      {
+        if (nano.msg[31 + x] < 0x10) Serial.print(F("0")); //Pretty print
+        Serial.print(nano.msg[31 + x], HEX);
+        Serial.print(F(" "));
+      }
+      Serial.print(",");
+      Serial.print(phase);
+      Serial.print("\n");
+    }
+  }
+}
+
+//Gracefully handles a reader that is already configured and already reading continuously. 
+//Because Stream does not have a .begin() we have to do this outside the library
+boolean setupNano(long baudRate)
+{
+  nano.begin(softSerial); //Tell the library to communicate over software serial port
+
+  //Test to see if we are already connected to a module
+  //This would be the case if the Arduino has been reprogrammed and the module has stayed powered
+  softSerial.begin(baudRate); //For this test, assume module is already at our desired baud rate
+  while (softSerial.isListening() == false); //Wait for port to open
+
+  //About 200ms from power on the module will send its firmware version at 115200. We need to ignore this.
+  while (softSerial.available()) softSerial.read();
+
+  nano.getVersion();
+
+  if (nano.msg[0] == ERROR_WRONG_OPCODE_RESPONSE)
+  {
+    //This happens if the baud rate is correct but the module is doing a ccontinuous read
+    nano.stopReading();
+
+    Serial.println(F("#Module continuously reading. Asking it to stop..."));
+
+    delay(1500);
+  }
+  else
+  {
+    //The module did not respond so assume it's just been powered on and communicating at 115200bps
+    softSerial.begin(115200); //Start software serial at 115200
+
+    nano.setBaud(baudRate); //Tell the module to go to the chosen baud rate. Ignore the response msg
+
+    softSerial.begin(baudRate); //Start the software serial port, this time at user's chosen baud rate
+
+    delay(250);
+  }
+
+  //Test the connection
+  nano.getVersion();
+  if (nano.msg[0] != ALL_GOOD) return (false); //Something is not right
+
+  //The M6E has these settings no matter what
+  nano.setTagProtocol(); //Set protocol to GEN2
+
+  nano.setAntennaPort(); //Set TX/RX antenna ports to 1
+
+  return (true); //We are ready to rock
+}
+
+
+// ----------------- LOOPS -----------------
+
+void setup()
+{
+  Serial.begin(115200);
+  while (!Serial); //Wait for the serial port to come online
+
+  if (setupNano(38400) == false) //Configure nano to run at 38400bps
+  {
+    Serial.println(F("#Module failed to respond. Please check wiring."));
+    while (1); //Freeze!
+  }
+
+  nano.setRegion(REGION_NORTHAMERICA); //Set to North America
+
+  nano.setReadPower(2700); //5.00 dBm. Higher values may caues USB port to brown out
+  //Max Read TX Power is 27.00 dBm and may cause temperature-limit throttling
+
+  Serial.println("#Scan tags in datalogging format? (y/n): ");
+  while (!Serial.available());
+  byte userInput = Serial.read();
+
+  switch (userInput) {
+    case 'y':
+      formatCheck = true;
+      break;
+    case 'n':
+      formatCheck = false;
+      break;
+    default:
+      Serial.println("#Error: invalid input");
+  }
+
+  Serial.println(F("#Press a key to begin scanning for tags. If datalogging with PuTTY or other terminal emulator, run it now. "));
+  while (!Serial.available()); //Wait for user to send a character
+  Serial.read(); //Throw away the user's character
+
+  if(formatCheck) {
+    Serial.print("rssi, freq, timestamp, epc, phase\n");  //Print CSV header
+  }
+
+  nano.startReading(); //Begin scanning for tags
+}
+
+void loop() {
+  if (formatCheck)
+    printAsCSV();
+  else
+    printWithLabels();
+}

--- a/test/README
+++ b/test/README
@@ -1,0 +1,11 @@
+
+This directory is intended for PlatformIO Test Runner and project tests.
+
+Unit Testing is a software testing method by which individual units of
+source code, sets of one or more MCU program modules together with associated
+control data, usage procedures, and operating procedures, are tested to
+determine whether they are fit for use. Unit testing finds problems early
+in the development cycle.
+
+More information about PlatformIO Unit Testing:
+- https://docs.platformio.org/en/latest/advanced/unit-testing/index.html


### PR DESCRIPTION
Added counter for tags scanned.
When datalogging, reader will scan until COUNT_MAX tags have been reached, then stop until user inputs to serial monitor.

OLD CHANGES:
-Separated loop function into printAsCSV and printWithLabels for options on how information is displayed by serial monitor.
-Added datalogging function (printAsCSV) that prints to serial monitor in csv format
    -Intended to be used with a terminal emulator (PuTTY) that saves serial monitor to csv
-Code compiles but none of this has been tested on the board yet
-Still no way to input grid coordinates for datalogging

TO DO:
-Ensure that format allows for processing in MATLAB (Check if EPC is readable and ensure # comments are ignored)
-Test with PuTTY and board
